### PR TITLE
TASK-10 feat: iOS 프로젝트 초기화 및 .gitignore/xcconfig 추가

### DIFF
--- a/frontend/NFTMintTransfer/.gitignore
+++ b/frontend/NFTMintTransfer/.gitignore
@@ -1,0 +1,58 @@
+# --- OS ---
+.DS_Store
+.AppleDouble
+.Spotlight-V100
+
+# --- Editors/IDE ---
+.idea/
+.vscode/*
+!.vscode/extensions.json
+
+# --- Node/FE ---
+node_modules/
+dist/
+out/
+.next/
+coverage/
+build/
+npm-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+*.log
+
+# --- Env/Secrets ---
+.env
+.env.*
+!.env.example
+
+# --- Xcode / Swift (iOS) ---
+# 빌드/파생 파일
+build/
+DerivedData/
+
+# 사용자별 Xcode 데이터
+*.xcuserdatad
+*.xcworkspace/xcuserdata
+*.xcodeproj/xcuserdata
+
+# Swift Package Manager
+.swiftpm/
+.build/
+.packages/
+
+# CocoaPods (사용 시)
+Pods/
+
+# Carthage (사용 시)
+Carthage/Build/
+
+# Fastlane (사용 시)
+fastlane/report.xml
+fastlane/test_output/
+
+# Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# --- iOS per-developer override (지금은 안 쓸 거면 생략해도 OK) ---
+Configs/LocalOverrides.xcconfig

--- a/frontend/NFTMintTransfer/Configs/Debug.xcconfig
+++ b/frontend/NFTMintTransfer/Configs/Debug.xcconfig
@@ -1,0 +1,2 @@
+#include "Configs/Shared.xcconfig"
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG

--- a/frontend/NFTMintTransfer/Configs/Release.xcconfig
+++ b/frontend/NFTMintTransfer/Configs/Release.xcconfig
@@ -1,0 +1,2 @@
+#include "Configs/Shared.xcconfig"
+SWIFT_ACTIVE_COMPILATION_CONDITIONS =

--- a/frontend/NFTMintTransfer/Configs/Shared.xcconfig
+++ b/frontend/NFTMintTransfer/Configs/Shared.xcconfig
@@ -1,0 +1,12 @@
+PRODUCT_NAME = $(TARGET_NAME)
+
+# 기본 번들 ID (로컬에서 덮어쓸 수 있게 ?= 사용)
+BUNDLE_ID ?= com.minseok.NFTMintTransfer
+PRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_ID)
+
+# 팀 ID는 비워두고 로컬에서만 override
+DEVELOPMENT_TEAM = 
+CODE_SIGN_STYLE = Automatic
+
+# 개인 로컬 오버라이드(있으면 읽음)
+#include? "Configs/LocalOverrides.xcconfig"

--- a/frontend/NFTMintTransfer/Debug 2.xcconfig
+++ b/frontend/NFTMintTransfer/Debug 2.xcconfig
@@ -1,0 +1,2 @@
+#include "Configs/Shared.xcconfig"
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG

--- a/frontend/NFTMintTransfer/Debug.xcconfig
+++ b/frontend/NFTMintTransfer/Debug.xcconfig
@@ -1,0 +1,2 @@
+#include "Configs/Shared.xcconfig"
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG

--- a/frontend/NFTMintTransfer/NFTMintTransfer.xcodeproj/project.pbxproj
+++ b/frontend/NFTMintTransfer/NFTMintTransfer.xcodeproj/project.pbxproj
@@ -6,6 +6,11 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		EE58A31D2E6C80AF00523237 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EE58A31C2E6C80AF00523237 /* Debug.xcconfig */; };
+		EE58A31F2E6C80C200523237 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EE58A31E2E6C80C200523237 /* Release.xcconfig */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		EE58A2EA2E6C715200523237 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -27,6 +32,8 @@
 		EE58A2D42E6C715100523237 /* NFTMintTransfer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NFTMintTransfer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE58A2E92E6C715200523237 /* NFTMintTransferTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NFTMintTransferTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE58A2F32E6C715200523237 /* NFTMintTransferUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NFTMintTransferUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EE58A31C2E6C80AF00523237 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		EE58A31E2E6C80C200523237 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -79,6 +86,9 @@
 				EE58A2EC2E6C715200523237 /* NFTMintTransferTests */,
 				EE58A2F62E6C715200523237 /* NFTMintTransferUITests */,
 				EE58A2D52E6C715100523237 /* Products */,
+				EE58A3072E6C772900523237 /* Configs */,
+				EE58A31C2E6C80AF00523237 /* Debug.xcconfig */,
+				EE58A31E2E6C80C200523237 /* Release.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -90,6 +100,13 @@
 				EE58A2F32E6C715200523237 /* NFTMintTransferUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		EE58A3072E6C772900523237 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Configs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -212,6 +229,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE58A31F2E6C80C200523237 /* Release.xcconfig in Resources */,
+				EE58A31D2E6C80AF00523237 /* Debug.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -271,6 +290,7 @@
 /* Begin XCBuildConfiguration section */
 		EE58A2FB2E6C715200523237 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EE58A31C2E6C80AF00523237 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -334,6 +354,7 @@
 		};
 		EE58A2FC2E6C715200523237 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EE58A31E2E6C80C200523237 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -446,6 +467,7 @@
 		};
 		EE58A3012E6C715200523237 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EE58A31C2E6C80AF00523237 /* Debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -464,6 +486,7 @@
 		};
 		EE58A3022E6C715200523237 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EE58A31E2E6C80C200523237 /* Release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -482,6 +505,7 @@
 		};
 		EE58A3042E6C715200523237 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EE58A31C2E6C80AF00523237 /* Debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -498,6 +522,7 @@
 		};
 		EE58A3052E6C715200523237 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EE58A31E2E6C80C200523237 /* Release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/frontend/NFTMintTransfer/NFTMintTransfer.xcodeproj/project.pbxproj
+++ b/frontend/NFTMintTransfer/NFTMintTransfer.xcodeproj/project.pbxproj
@@ -1,0 +1,557 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		EE58A2EA2E6C715200523237 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EE58A2CC2E6C715100523237 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EE58A2D32E6C715100523237;
+			remoteInfo = NFTMintTransfer;
+		};
+		EE58A2F42E6C715200523237 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EE58A2CC2E6C715100523237 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EE58A2D32E6C715100523237;
+			remoteInfo = NFTMintTransfer;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		EE58A2D42E6C715100523237 /* NFTMintTransfer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NFTMintTransfer.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		EE58A2E92E6C715200523237 /* NFTMintTransferTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NFTMintTransferTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EE58A2F32E6C715200523237 /* NFTMintTransferUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NFTMintTransferUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		EE58A2D62E6C715100523237 /* NFTMintTransfer */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = NFTMintTransfer;
+			sourceTree = "<group>";
+		};
+		EE58A2EC2E6C715200523237 /* NFTMintTransferTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = NFTMintTransferTests;
+			sourceTree = "<group>";
+		};
+		EE58A2F62E6C715200523237 /* NFTMintTransferUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = NFTMintTransferUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		EE58A2D12E6C715100523237 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EE58A2E62E6C715200523237 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EE58A2F02E6C715200523237 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		EE58A2CB2E6C715100523237 = {
+			isa = PBXGroup;
+			children = (
+				EE58A2D62E6C715100523237 /* NFTMintTransfer */,
+				EE58A2EC2E6C715200523237 /* NFTMintTransferTests */,
+				EE58A2F62E6C715200523237 /* NFTMintTransferUITests */,
+				EE58A2D52E6C715100523237 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		EE58A2D52E6C715100523237 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EE58A2D42E6C715100523237 /* NFTMintTransfer.app */,
+				EE58A2E92E6C715200523237 /* NFTMintTransferTests.xctest */,
+				EE58A2F32E6C715200523237 /* NFTMintTransferUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		EE58A2D32E6C715100523237 /* NFTMintTransfer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EE58A2FD2E6C715200523237 /* Build configuration list for PBXNativeTarget "NFTMintTransfer" */;
+			buildPhases = (
+				EE58A2D02E6C715100523237 /* Sources */,
+				EE58A2D12E6C715100523237 /* Frameworks */,
+				EE58A2D22E6C715100523237 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				EE58A2D62E6C715100523237 /* NFTMintTransfer */,
+			);
+			name = NFTMintTransfer;
+			packageProductDependencies = (
+			);
+			productName = NFTMintTransfer;
+			productReference = EE58A2D42E6C715100523237 /* NFTMintTransfer.app */;
+			productType = "com.apple.product-type.application";
+		};
+		EE58A2E82E6C715200523237 /* NFTMintTransferTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EE58A3002E6C715200523237 /* Build configuration list for PBXNativeTarget "NFTMintTransferTests" */;
+			buildPhases = (
+				EE58A2E52E6C715200523237 /* Sources */,
+				EE58A2E62E6C715200523237 /* Frameworks */,
+				EE58A2E72E6C715200523237 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EE58A2EB2E6C715200523237 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				EE58A2EC2E6C715200523237 /* NFTMintTransferTests */,
+			);
+			name = NFTMintTransferTests;
+			packageProductDependencies = (
+			);
+			productName = NFTMintTransferTests;
+			productReference = EE58A2E92E6C715200523237 /* NFTMintTransferTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		EE58A2F22E6C715200523237 /* NFTMintTransferUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EE58A3032E6C715200523237 /* Build configuration list for PBXNativeTarget "NFTMintTransferUITests" */;
+			buildPhases = (
+				EE58A2EF2E6C715200523237 /* Sources */,
+				EE58A2F02E6C715200523237 /* Frameworks */,
+				EE58A2F12E6C715200523237 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EE58A2F52E6C715200523237 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				EE58A2F62E6C715200523237 /* NFTMintTransferUITests */,
+			);
+			name = NFTMintTransferUITests;
+			packageProductDependencies = (
+			);
+			productName = NFTMintTransferUITests;
+			productReference = EE58A2F32E6C715200523237 /* NFTMintTransferUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		EE58A2CC2E6C715100523237 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					EE58A2D32E6C715100523237 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+					EE58A2E82E6C715200523237 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = EE58A2D32E6C715100523237;
+					};
+					EE58A2F22E6C715200523237 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = EE58A2D32E6C715100523237;
+					};
+				};
+			};
+			buildConfigurationList = EE58A2CF2E6C715100523237 /* Build configuration list for PBXProject "NFTMintTransfer" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EE58A2CB2E6C715100523237;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = EE58A2D52E6C715100523237 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				EE58A2D32E6C715100523237 /* NFTMintTransfer */,
+				EE58A2E82E6C715200523237 /* NFTMintTransferTests */,
+				EE58A2F22E6C715200523237 /* NFTMintTransferUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		EE58A2D22E6C715100523237 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EE58A2E72E6C715200523237 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EE58A2F12E6C715200523237 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		EE58A2D02E6C715100523237 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EE58A2E52E6C715200523237 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EE58A2EF2E6C715200523237 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		EE58A2EB2E6C715200523237 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EE58A2D32E6C715100523237 /* NFTMintTransfer */;
+			targetProxy = EE58A2EA2E6C715200523237 /* PBXContainerItemProxy */;
+		};
+		EE58A2F52E6C715200523237 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EE58A2D32E6C715100523237 /* NFTMintTransfer */;
+			targetProxy = EE58A2F42E6C715200523237 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		EE58A2FB2E6C715200523237 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		EE58A2FC2E6C715200523237 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		EE58A2FE2E6C715200523237 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"NFTMintTransfer/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "-23.NFTMintTransfer";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		EE58A2FF2E6C715200523237 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"NFTMintTransfer/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "-23.NFTMintTransfer";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		EE58A3012E6C715200523237 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "-23.NFTMintTransferTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NFTMintTransfer.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/NFTMintTransfer";
+			};
+			name = Debug;
+		};
+		EE58A3022E6C715200523237 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "-23.NFTMintTransferTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NFTMintTransfer.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/NFTMintTransfer";
+			};
+			name = Release;
+		};
+		EE58A3042E6C715200523237 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "-23.NFTMintTransferUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = NFTMintTransfer;
+			};
+			name = Debug;
+		};
+		EE58A3052E6C715200523237 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "-23.NFTMintTransferUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = NFTMintTransfer;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		EE58A2CF2E6C715100523237 /* Build configuration list for PBXProject "NFTMintTransfer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EE58A2FB2E6C715200523237 /* Debug */,
+				EE58A2FC2E6C715200523237 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EE58A2FD2E6C715200523237 /* Build configuration list for PBXNativeTarget "NFTMintTransfer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EE58A2FE2E6C715200523237 /* Debug */,
+				EE58A2FF2E6C715200523237 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EE58A3002E6C715200523237 /* Build configuration list for PBXNativeTarget "NFTMintTransferTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EE58A3012E6C715200523237 /* Debug */,
+				EE58A3022E6C715200523237 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EE58A3032E6C715200523237 /* Build configuration list for PBXNativeTarget "NFTMintTransferUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EE58A3042E6C715200523237 /* Debug */,
+				EE58A3052E6C715200523237 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = EE58A2CC2E6C715100523237 /* Project object */;
+}

--- a/frontend/NFTMintTransfer/NFTMintTransfer.xcodeproj/project.pbxproj
+++ b/frontend/NFTMintTransfer/NFTMintTransfer.xcodeproj/project.pbxproj
@@ -6,11 +6,6 @@
 	objectVersion = 77;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		EE58A31D2E6C80AF00523237 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EE58A31C2E6C80AF00523237 /* Debug.xcconfig */; };
-		EE58A31F2E6C80C200523237 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EE58A31E2E6C80C200523237 /* Release.xcconfig */; };
-/* End PBXBuildFile section */
-
 /* Begin PBXContainerItemProxy section */
 		EE58A2EA2E6C715200523237 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -32,8 +27,9 @@
 		EE58A2D42E6C715100523237 /* NFTMintTransfer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NFTMintTransfer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE58A2E92E6C715200523237 /* NFTMintTransferTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NFTMintTransferTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE58A2F32E6C715200523237 /* NFTMintTransferUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NFTMintTransferUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		EE58A31C2E6C80AF00523237 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		EE58A31E2E6C80C200523237 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		EE58A3382E6C84F300523237 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		EE58A3392E6C84F300523237 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		EE58A33A2E6C84F300523237 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -82,13 +78,11 @@
 		EE58A2CB2E6C715100523237 = {
 			isa = PBXGroup;
 			children = (
+				EE58A33B2E6C84F300523237 /* Configs */,
 				EE58A2D62E6C715100523237 /* NFTMintTransfer */,
 				EE58A2EC2E6C715200523237 /* NFTMintTransferTests */,
 				EE58A2F62E6C715200523237 /* NFTMintTransferUITests */,
 				EE58A2D52E6C715100523237 /* Products */,
-				EE58A3072E6C772900523237 /* Configs */,
-				EE58A31C2E6C80AF00523237 /* Debug.xcconfig */,
-				EE58A31E2E6C80C200523237 /* Release.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -102,9 +96,12 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		EE58A3072E6C772900523237 /* Configs */ = {
+		EE58A33B2E6C84F300523237 /* Configs */ = {
 			isa = PBXGroup;
 			children = (
+				EE58A3382E6C84F300523237 /* Debug.xcconfig */,
+				EE58A3392E6C84F300523237 /* Release.xcconfig */,
+				EE58A33A2E6C84F300523237 /* Shared.xcconfig */,
 			);
 			path = Configs;
 			sourceTree = "<group>";
@@ -229,8 +226,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EE58A31F2E6C80C200523237 /* Release.xcconfig in Resources */,
-				EE58A31D2E6C80AF00523237 /* Debug.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -290,7 +285,7 @@
 /* Begin XCBuildConfiguration section */
 		EE58A2FB2E6C715200523237 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE58A31C2E6C80AF00523237 /* Debug.xcconfig */;
+			baseConfigurationReference = EE58A3382E6C84F300523237 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -354,7 +349,7 @@
 		};
 		EE58A2FC2E6C715200523237 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE58A31E2E6C80C200523237 /* Release.xcconfig */;
+			baseConfigurationReference = EE58A3392E6C84F300523237 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -467,7 +462,7 @@
 		};
 		EE58A3012E6C715200523237 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE58A31C2E6C80AF00523237 /* Debug.xcconfig */;
+			baseConfigurationReference = EE58A3382E6C84F300523237 /* Debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -486,7 +481,7 @@
 		};
 		EE58A3022E6C715200523237 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE58A31E2E6C80C200523237 /* Release.xcconfig */;
+			baseConfigurationReference = EE58A3392E6C84F300523237 /* Release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -505,7 +500,7 @@
 		};
 		EE58A3042E6C715200523237 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE58A31C2E6C80AF00523237 /* Debug.xcconfig */;
+			baseConfigurationReference = EE58A3382E6C84F300523237 /* Debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -522,7 +517,7 @@
 		};
 		EE58A3052E6C715200523237 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE58A31E2E6C80C200523237 /* Release.xcconfig */;
+			baseConfigurationReference = EE58A3392E6C84F300523237 /* Release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/frontend/NFTMintTransfer/NFTMintTransfer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/frontend/NFTMintTransfer/NFTMintTransfer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/frontend/NFTMintTransfer/NFTMintTransfer/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/NFTMintTransfer/NFTMintTransfer/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/NFTMintTransfer/NFTMintTransfer/Assets.xcassets/Contents.json
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/NFTMintTransfer/NFTMintTransfer/ContentView.swift
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/ContentView.swift
@@ -1,0 +1,86 @@
+//
+//  ContentView.swift
+//  NFTMintTransfer
+//
+//  Created by 이민석 on 9/6/25.
+//
+
+import SwiftUI
+import CoreData
+
+struct ContentView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Item.timestamp, ascending: true)],
+        animation: .default)
+    private var items: FetchedResults<Item>
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(items) { item in
+                    NavigationLink {
+                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
+                    } label: {
+                        Text(item.timestamp!, formatter: itemFormatter)
+                    }
+                }
+                .onDelete(perform: deleteItems)
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    EditButton()
+                }
+                ToolbarItem {
+                    Button(action: addItem) {
+                        Label("Add Item", systemImage: "plus")
+                    }
+                }
+            }
+            Text("Select an item")
+        }
+    }
+
+    private func addItem() {
+        withAnimation {
+            let newItem = Item(context: viewContext)
+            newItem.timestamp = Date()
+
+            do {
+                try viewContext.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nsError = error as NSError
+                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+            }
+        }
+    }
+
+    private func deleteItems(offsets: IndexSet) {
+        withAnimation {
+            offsets.map { items[$0] }.forEach(viewContext.delete)
+
+            do {
+                try viewContext.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nsError = error as NSError
+                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+            }
+        }
+    }
+}
+
+private let itemFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .short
+    formatter.timeStyle = .medium
+    return formatter
+}()
+
+#Preview {
+    ContentView().environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+}

--- a/frontend/NFTMintTransfer/NFTMintTransfer/NFTMintTransfer.xcdatamodeld/.xccurrentversion
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/NFTMintTransfer.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>NFTMintTransfer.xcdatamodel</string>
+</dict>
+</plist>

--- a/frontend/NFTMintTransfer/NFTMintTransfer/NFTMintTransfer.xcdatamodeld/NFTMintTransfer.xcdatamodel/contents
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/NFTMintTransfer.xcdatamodeld/NFTMintTransfer.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
+    <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <elements>
+        <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
+    </elements>
+</model>

--- a/frontend/NFTMintTransfer/NFTMintTransfer/NFTMintTransferApp.swift
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/NFTMintTransferApp.swift
@@ -1,0 +1,20 @@
+//
+//  NFTMintTransferApp.swift
+//  NFTMintTransfer
+//
+//  Created by 이민석 on 9/6/25.
+//
+
+import SwiftUI
+
+@main
+struct NFTMintTransferApp: App {
+    let persistenceController = PersistenceController.shared
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+        }
+    }
+}

--- a/frontend/NFTMintTransfer/NFTMintTransfer/Persistence.swift
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/Persistence.swift
@@ -1,0 +1,57 @@
+//
+//  Persistence.swift
+//  NFTMintTransfer
+//
+//  Created by 이민석 on 9/6/25.
+//
+
+import CoreData
+
+struct PersistenceController {
+    static let shared = PersistenceController()
+
+    @MainActor
+    static let preview: PersistenceController = {
+        let result = PersistenceController(inMemory: true)
+        let viewContext = result.container.viewContext
+        for _ in 0..<10 {
+            let newItem = Item(context: viewContext)
+            newItem.timestamp = Date()
+        }
+        do {
+            try viewContext.save()
+        } catch {
+            // Replace this implementation with code to handle the error appropriately.
+            // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+            let nsError = error as NSError
+            fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+        }
+        return result
+    }()
+
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "NFTMintTransfer")
+        if inMemory {
+            container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+}

--- a/frontend/NFTMintTransfer/NFTMintTransfer/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/frontend/NFTMintTransfer/NFTMintTransfer/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/NFTMintTransfer/NFTMintTransferTests/NFTMintTransferTests.swift
+++ b/frontend/NFTMintTransfer/NFTMintTransferTests/NFTMintTransferTests.swift
@@ -1,0 +1,17 @@
+//
+//  NFTMintTransferTests.swift
+//  NFTMintTransferTests
+//
+//  Created by 이민석 on 9/6/25.
+//
+
+import Testing
+@testable import NFTMintTransfer
+
+struct NFTMintTransferTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/frontend/NFTMintTransfer/NFTMintTransferUITests/NFTMintTransferUITests.swift
+++ b/frontend/NFTMintTransfer/NFTMintTransferUITests/NFTMintTransferUITests.swift
@@ -1,0 +1,43 @@
+//
+//  NFTMintTransferUITests.swift
+//  NFTMintTransferUITests
+//
+//  Created by 이민석 on 9/6/25.
+//
+
+import XCTest
+
+final class NFTMintTransferUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/frontend/NFTMintTransfer/NFTMintTransferUITests/NFTMintTransferUITestsLaunchTests.swift
+++ b/frontend/NFTMintTransfer/NFTMintTransferUITests/NFTMintTransferUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  NFTMintTransferUITestsLaunchTests.swift
+//  NFTMintTransferUITests
+//
+//  Created by 이민석 on 9/6/25.
+//
+
+import XCTest
+
+final class NFTMintTransferUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/frontend/NFTMintTransfer/Release.xcconfig
+++ b/frontend/NFTMintTransfer/Release.xcconfig
@@ -1,0 +1,2 @@
+#include "Configs/Shared.xcconfig"
+SWIFT_ACTIVE_COMPILATION_CONDITIONS =


### PR DESCRIPTION
### 개요 (Overview)  
iOS 프로젝트 초기화 및 협업 환경 개선을 위한 기본 설정 추가  

---

### 변경사항 (Key Changes)  
- iOS 프로젝트(`NFTMintTransfer`) 생성  
- `.gitignore` 추가  
  - macOS 시스템 파일 무시  
  - Xcode 빌드 산출물/사용자 데이터 무시  
  - SwiftPM/Pods/Carthage/Fastlane 산출물 무시  
  - `.env` 무시 (단 `.env.example` 포함)  
  - `LocalOverrides.xcconfig` 무시  
- `xcconfig` 3종 추가  
  - `Shared.xcconfig` (공통 설정)  
  - `Debug.xcconfig` (디버그 전용)  
  - `Release.xcconfig` (릴리즈 전용)  
- PROJECT 및 TARGETS의 Base Configuration을 `Configs/Debug.xcconfig`, `Configs/Release.xcconfig`로 연결  
- 루트에 잘못 생성된 중복 `Debug.xcconfig`, `Release.xcconfig` 제거 후 `Configs` 그룹으로 재추가  

---

### 기타 (To Reviewer)  
- 현재까지는 프로젝트 초기화 및 환경 설정 작업입니다.  
- 다음 단계에서 진행 예정:  
  - `docker-compose.yml` 환경 변수 분리 (`.env` → `.env.example`)  
  - SwiftUI 코드 내 `fatalError` 개선 및 안정성 강화  

---

### Commit History  
1. **chore(ios): .gitignore 및 xcconfig(Shared/Debug/Release) 추가**  
   - `.gitignore` 작성 및 불필요/민감 파일 무시 규칙 추가  
   - `Configs/Shared.xcconfig`, `Configs/Debug.xcconfig`, `Configs/Release.xcconfig` 추가  

2. **chore(ios): 프로젝트 및 테스트 타깃 Base Configuration에 xcconfig 연결**  
   - PROJECT / TARGETS의 Base Configuration 지정  
   - 루트에 `Debug.xcconfig`, `Release.xcconfig` 잘못 생성  

3. **fix(ios): Configs 폴더 재추가 및 Base Configuration를 Configs/*.xcconfig로 정정**  
   - 루트에 잘못 생성된 xcconfig 제거  
   - Configs 그룹으로 재추가 후 올바른 파일 참조로 수정  